### PR TITLE
Add PHPStan static analysis setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,14 @@
   <h1>Openapi® client for PHP</h1>
   <h4>The perfect starting point to integrate <a href="https://openapi.com/">Openapi®</a> within your PHP project</h4>
 
-  [![Build Status](https://github.com/openapi/openapi-php-sdk/actions/workflows/php.yml/badge.svg)](https://github.com/openapi/openapi-php-sdk/actions/workflows/php.yml)
-  [![Packagist Version](https://img.shields.io/packagist/v/openapi/openapi-sdk)](https://packagist.org/packages/openapi/openapi-sdk)
-  [![PHP Version](https://img.shields.io/packagist/php-v/openapi/openapi-sdk)](https://packagist.org/packages/openapi/openapi-sdk)
-  [![License](https://img.shields.io/github/license/openapi/openapi-php-sdk?v=2)](LICENSE)
-  [![Downloads](https://img.shields.io/packagist/dt/openapi/openapi-sdk)](https://packagist.org/packages/openapi/openapi-sdk)
-  <br>
+[![Build Status](https://github.com/openapi/openapi-php-sdk/actions/workflows/php.yml/badge.svg)](https://github.com/openapi/openapi-php-sdk/actions/workflows/php.yml)
+[![Packagist Version](https://img.shields.io/packagist/v/openapi/openapi-sdk)](https://packagist.org/packages/openapi/openapi-sdk)
+[![PHP Version](https://img.shields.io/packagist/php-v/openapi/openapi-sdk)](https://packagist.org/packages/openapi/openapi-sdk)
+[![License](https://img.shields.io/github/license/openapi/openapi-php-sdk?v=2)](LICENSE)
+[![Downloads](https://img.shields.io/packagist/dt/openapi/openapi-sdk)](https://packagist.org/packages/openapi/openapi-sdk)
+<br>
 [![Linux Foundation Member](https://img.shields.io/badge/Linux%20Foundation-Silver%20Member-003778?logo=linux-foundation&logoColor=white)](https://www.linuxfoundation.org/about/members)
+
 </div>
 
 ## Overview
@@ -27,9 +28,10 @@ Before using the Openapi PHP Client, you will need an account at [Openapi](https
 
 - **Agnostic Design**: No API-specific classes, works with any Openapi service
 - **Minimal Dependencies**: Only requires PHP 8.0+ and cURL
-- **OAuth Support**: Built-in OAuth client for token management  
+- **OAuth Support**: Built-in OAuth client for token management
 - **HTTP Primitives**: GET, POST, PUT, DELETE, PATCH methods
 - **Clean Interface**: Similar to the Rust SDK design
+- **Static Analysis**: PHPStan level 6 configuration available via Composer
 
 ## What you can do
 
@@ -81,7 +83,7 @@ $client = new Client($token);
 $params = ['denominazione' => 'Stellantis', 'provincia' => 'TO'];
 $response = $client->get('https://test.company.openapi.com/IT-advanced', $params);
 
-// POST request  
+// POST request
 $payload = ['limit' => 10, 'query' => ['country_code' => 'IT']];
 $response = $client->post('https://test.postontarget.com/fields/country', $payload);
 
@@ -134,6 +136,17 @@ composer run test
 composer run test:unit
 ```
 
+## Static Analysis
+
+This SDK includes PHPStan as a Composer development dependency to help keep the codebase type-safe and maintainable.
+
+PHPStan is configured in `phpstan.neon` and currently runs at level 6.
+
+Run static analysis with:
+
+```bash
+composer run analyse
+```
 
 ## Contributing
 
@@ -165,9 +178,9 @@ Meet our partners using Openapi or contributing to this SDK:
 
 ## Our Commitments
 
-We believe in open source and we act on that belief. We became Silver Members 
-of the Linux Foundation because we wanted to formally support the ecosystem 
-we build on every day. Open standards, open collaboration, and open governance 
+We believe in open source and we act on that belief. We became Silver Members
+of the Linux Foundation because we wanted to formally support the ecosystem
+we build on every day. Open standards, open collaboration, and open governance
 are part of how we work and how we think about software.
 
 ## License
@@ -179,4 +192,3 @@ The MIT License is a permissive open-source license that allows you to freely us
 In short, you are free to use this SDK in your personal, academic, or commercial projects, with minimal restrictions. The project is provided "as-is", without any warranty of any kind, either expressed or implied, including but not limited to the warranties of merchantability, fitness for a particular purpose, and non-infringement.
 
 For more details, see the full license text at the [MIT License page](https://choosealicense.com/licenses/mit/).
-

--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,8 @@
     },
     "require-dev": {
         "symfony/dotenv": "^5.3",
-        "phpunit/phpunit": "^9.5"
+        "phpunit/phpunit": "^9.5",
+        "phpstan/phpstan": "^2.1"
     },
     "autoload": {
         "psr-4": {
@@ -67,6 +68,7 @@
         }
     },
     "scripts": {
+        "analyse": "vendor/bin/phpstan analyse -c phpstan.neon",
         "test": "phpunit tests/",
         "test:unit": "phpunit tests/ --testsuite=unit",
         "example:token": "php examples/token_generation.php",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,5 @@
+parameters:
+	level: 6
+	paths:
+		- src
+		- tests

--- a/src/Cache/ArrayCache.php
+++ b/src/Cache/ArrayCache.php
@@ -4,7 +4,13 @@ namespace Openapi\Cache;
 
 class ArrayCache implements CacheInterface
 {
+     /**
+     * @var array<string, mixed>
+     */
     private array $cache = [];
+    /**
+     * @var array<string, int>
+     */
     private array $expiry = [];
 
     public function get(string $key): mixed

--- a/src/Client.php
+++ b/src/Client.php
@@ -21,6 +21,15 @@ class Client
         $this->transport = $transport ?? new CurlTransport($this->token);
     }
 
+    /**
+     * Execute HTTP request
+     *
+     * @param string $method HTTP method (GET, POST, PUT, DELETE, PATCH)
+     * @param string $url Target URL
+     * @param mixed $payload Request body (for POST/PUT/PATCH)
+     * @param array<string, scalar|null>|null $params Query parameters (for GET) or form data (for other methods)
+     * @return string Response body
+     */
     public function request(
         string $method,
         string $url,
@@ -34,6 +43,11 @@ class Client
         return $this->transport->request($method, $url, $payload, $params);
     }
 
+    /**
+     * Execute GET request
+     *
+     * @param array<string, scalar|null>|null $params Query parameters
+     */
     public function get(string $url, ?array $params = null): string
     {
         return $this->request('GET', $url, null, $params);

--- a/src/Interfaces/HttpTransportInterface.php
+++ b/src/Interfaces/HttpTransportInterface.php
@@ -4,10 +4,13 @@ namespace Openapi\Interfaces;
 
 interface HttpTransportInterface
 {
+     /**
+     * @param array<string, mixed>|string|null $params
+     */
     public function request(
         string $method,
         string $url,
         mixed $payload = null,
-        ?array $params = null
+        array|string|null $params = null
     ): string;
 }

--- a/src/OauthClient.php
+++ b/src/OauthClient.php
@@ -28,6 +28,9 @@ class OauthClient
         return $this->request('GET', $url);
     }
 
+    /**
+     * @param list<string> $scopes
+     */
     public function createToken(array $scopes, int $ttl = 3600): string
     {
         $body = [
@@ -56,6 +59,10 @@ class OauthClient
         return $this->request('GET', $this->url . '/counters/' . $period . '/' . $date);
     }
 
+    
+    /**
+     * @param array<string, mixed>|null $body
+     */
     private function request(string $method, string $url, ?array $body = null): string
     {
         $ch = curl_init();

--- a/src/Transports/CurlTransport.php
+++ b/src/Transports/CurlTransport.php
@@ -14,7 +14,7 @@ final class CurlTransport implements HttpTransportInterface
         string $method,
         string $url,
         mixed $payload = null,
-        ?array $params = null
+        array|string|null $params = null
     ): string {
         if ($params && $method === 'GET') {
             $url .= '?' . http_build_query($params);

--- a/tests/Transports/FakeTransport.php
+++ b/tests/Transports/FakeTransport.php
@@ -9,14 +9,17 @@ final class FakeTransport implements HttpTransportInterface
     public ?string $lastMethod = null;
     public ?string $lastUrl = null;
     public mixed $lastPayload = null;
-    public ?array $lastParams = null;
+     /**
+     * @var array<string, mixed>|string|null
+     */
+    public array|string|null $lastParams = null;
     public int $callCount = 0;
 
     public function request(
         string $method,
         string $url,
         mixed $payload = null,
-        ?array $params = null
+        array|string|null $params = null
     ): string {
         $this->callCount++;
         $this->lastMethod = $method;


### PR DESCRIPTION
#21 Add PHPStan as a Composer dev dependency, configure phpstan.neon at level 6, add the Composer analyse script, and fix reported iterable type issues across the SDK and tests. Integration tests requiring valid tokens remain skipped.

## 📋 Description

Brief description of the changes made in this PR.

## ✨ Type of Change

- [ ] 🐛 Bug fix (fixes an issue)
- [x] ✨ New feature (adds functionality)
- [x] 🔧 Refactoring (code restructuring without functional changes)
- [x] 📚 Documentation (updates to documentation)
- [ ] 🧪 Tests (adding or modifying tests)
- [ ] 🔒 Security (security-related fixes)
- [ ] ⚡ Performance (performance improvements)
- [ ] 🎨 Style (formatting changes, no logic changes)

## 🔍 Main Changes
Add PHPStan static analysis setup

- Add PHPStan as a Composer dev dependency
- Add phpstan.neon configuration with level 6
- Add Composer analyse script
- Fix PHPStan iterable type issues across the SDK and tests
- Keep integration tests skipped when valid tokens are required

## 🧪 Testing

- [x] I have tested the changes locally
- [ ] I have added/updated unit tests
- [ ] All tests pass (`./vendor/bin/phpunit`)
- [x] I have verified PHP 8.0+ compatibility

## 📝 Additional Notes

Any additional information, considerations, or important context for reviewers.

## 🔗 Related Issue

Closes #21 (if applicable)

## 📸 Screenshots (if applicable)

If changes affect the interface or visible behavior, include screenshots.

## ✅ Checklist

- [x] My code follows the project conventions
- [x] I have performed a self-review of my code
- [x] I have commented complex code where necessary
- [x] Documentation has been updated (if needed)
- [x] I have not introduced breaking changes (or documented them)
- [x] I have verified no sensitive information is in the code